### PR TITLE
fix linux 64 bit build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -162,15 +162,20 @@ fn main() {
 
     let dst = config.build();
 
-    let mut libdir_path = dst.clone();
+    // Sometimes the path can be called lib64
+    let libdir_path = ["lib", "lib64"]
+        .iter()
+        .map(|dir| dst.clone().join(dir))
+        .find(|path| path.exists())
+        .unwrap_or_else(|| {
+            panic!(
+                "Could not find rtaudio static lib path. Check `target/debug/build/rtaudio-sys-*/out` for a lib or lib64 folder."
+            );
+        });
 
-    // TODO: Check if this is true for all linux 64 bit
-    #[cfg(target_os = "linux")]
-    #[cfg(target_pointer_width = "64")]
-    libdir_path.push("lib64");
-
-    #[cfg(not(target_os = "linux"))]
-    libdir_path.push("lib");
+    if !libdir_path.exists() {
+        panic!("Could not find rtaudio static lib path. Check `target/debug/build/rtaudio-sys-*/out/` for a lib or lib64 folder.");
+    }
 
     // Tell cargo to link to the compiled library.
     println!(

--- a/build.rs
+++ b/build.rs
@@ -163,6 +163,13 @@ fn main() {
     let dst = config.build();
 
     let mut libdir_path = dst.clone();
+
+    // TODO: Check if this is true for all linux 64 bit
+    #[cfg(target_os = "linux")]
+    #[cfg(target_pointer_width = "64")]
+    libdir_path.push("lib64");
+
+    #[cfg(not(target_os = "linux"))]
     libdir_path.push("lib");
 
     // Tell cargo to link to the compiled library.

--- a/build.rs
+++ b/build.rs
@@ -173,10 +173,6 @@ fn main() {
             );
         });
 
-    if !libdir_path.exists() {
-        panic!("Could not find rtaudio static lib path. Check `target/debug/build/rtaudio-sys-*/out/` for a lib or lib64 folder.");
-    }
-
     // Tell cargo to link to the compiled library.
     println!(
         "cargo:rustc-link-search=native={}",


### PR DESCRIPTION
On my fedora machine rtaudio-rs was not building, because it couldn't find the static library.
After investigating the output directory I saw that the library is in a folder called `lib64`, the build script is expecting the folder to be called `lib`, so I changed the build script to  look for `lib64` when it is building for linux 64 bit.

I can not say right now, if the folder is the same on every linux distribution, but on Fedora it compiles now.
