### PR TITLE
Fix Windows Release Build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -185,7 +185,10 @@ fn main() {
     }
     #[cfg(target_os = "windows")]
     {
+        #[cfg(debug_assertions)]
         println!("cargo:rustc-link-lib=static=rtaudiod");
+        #[cfg(not(debug_assertions))]
+        println!("cargo:rustc-link-lib=static=rtaudio");
     }
 
     /*


### PR DESCRIPTION
As mentioned in #3 this is changing the windows build to use `rtaudio.lib`instead of `rtaudiod.lib` in release mode. Tested on current Windows 11.